### PR TITLE
feat: implement catalog API module with new URL scheme

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/doron-cohen/argus/backend/internal/storage"
 )
@@ -286,20 +285,6 @@ func (s *APIServer) writeJSONResponse(w http.ResponseWriter, response interface{
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		http.Error(w, "failed to encode response", http.StatusInternalServerError)
-		return
-	}
-}
-
-func (s *APIServer) GetHealth(w http.ResponseWriter, r *http.Request) {
-	health := Health{
-		Status:    Healthy,
-		Timestamp: time.Now(),
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(health); err != nil {
 		http.Error(w, "failed to encode response", http.StatusInternalServerError)
 		return
 	}

--- a/backend/api/handlers_test.go
+++ b/backend/api/handlers_test.go
@@ -25,7 +25,7 @@ func TestGetComponentReports(t *testing.T) {
 		_, _, report := createTestData(t, repo)
 
 		// Create request
-		req := httptest.NewRequest("GET", "/components/test-component/reports", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component/reports", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -41,7 +41,7 @@ func TestGetComponentReports(t *testing.T) {
 
 	t.Run("ComponentNotFound", func(t *testing.T) {
 		// Create request for non-existent component
-		req := httptest.NewRequest("GET", "/components/non-existent/reports", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/non-existent/reports", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -154,7 +154,7 @@ func TestGetComponentReports_ValidationErrors(t *testing.T) {
 
 	t.Run("InvalidLimit", func(t *testing.T) {
 		// Create request with invalid limit
-		req := httptest.NewRequest("GET", "/components/test-component-validation/reports?limit=-1", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-validation/reports?limit=-1", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -169,7 +169,7 @@ func TestGetComponentReports_ValidationErrors(t *testing.T) {
 
 	t.Run("InvalidOffset", func(t *testing.T) {
 		// Create request with invalid offset
-		req := httptest.NewRequest("GET", "/components/test-component-validation/reports?offset=-1", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-validation/reports?offset=-1", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -184,7 +184,7 @@ func TestGetComponentReports_ValidationErrors(t *testing.T) {
 
 	t.Run("ExcessiveLimit", func(t *testing.T) {
 		// Create request with excessive limit
-		req := httptest.NewRequest("GET", "/components/test-component-validation/reports?limit=10000", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-validation/reports?limit=10000", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -222,7 +222,7 @@ func TestGetComponentReports_EdgeCases(t *testing.T) {
 
 	t.Run("EmptyComponent", func(t *testing.T) {
 		// Create request for component with no reports
-		req := httptest.NewRequest("GET", "/components/test-component-edgecases/reports", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-edgecases/reports", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -241,7 +241,7 @@ func TestGetComponentReports_EdgeCases(t *testing.T) {
 
 	t.Run("InvalidSinceDate", func(t *testing.T) {
 		// Create request with invalid since date
-		req := httptest.NewRequest("GET", "/components/test-component-edgecases/reports?since=invalid-date", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-edgecases/reports?since=invalid-date", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler - this will fail at the OpenAPI validation level
@@ -254,7 +254,7 @@ func TestGetComponentReports_EdgeCases(t *testing.T) {
 
 	t.Run("FutureSinceDate", func(t *testing.T) {
 		// Create request with future since date
-		req := httptest.NewRequest("GET", "/components/test-component-edgecases/reports?since=2030-01-01T00:00:00Z", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-edgecases/reports?since=2030-01-01T00:00:00Z", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -320,7 +320,7 @@ func TestGetComponentReports_Pagination(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create request
-			req := httptest.NewRequest("GET", fmt.Sprintf("/components/test-component-pagination/reports?limit=%d&offset=%d", tc.limit, tc.offset), nil)
+			req := httptest.NewRequest("GET", fmt.Sprintf("/catalog/v1/components/test-component-pagination/reports?limit=%d&offset=%d", tc.limit, tc.offset), nil)
 			w := httptest.NewRecorder()
 
 			// Call handler
@@ -399,7 +399,7 @@ func TestGetComponentReports_PaginationLimit(t *testing.T) {
 
 	t.Run("ExcessiveLimitShouldBeCapped", func(t *testing.T) {
 		// Create request with excessive limit (should be capped to 100)
-		req := httptest.NewRequest("GET", "/components/test-component-limit/reports?limit=10000", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-limit/reports?limit=10000", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -422,7 +422,7 @@ func TestGetComponentReports_PaginationLimit(t *testing.T) {
 
 	t.Run("ValidLimitShouldBeRespected", func(t *testing.T) {
 		// Create request with valid limit
-		req := httptest.NewRequest("GET", "/components/test-component-limit/reports?limit=25", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-limit/reports?limit=25", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler
@@ -461,7 +461,7 @@ func TestGetComponentReports_InvalidStatusParameter(t *testing.T) {
 
 	t.Run("InvalidStatusReturns200Not400", func(t *testing.T) {
 		// Create request with invalid status parameter
-		req := httptest.NewRequest("GET", "/components/test-component-status/reports?status=invalid-status", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-status/reports?status=invalid-status", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler with invalid status
@@ -480,7 +480,7 @@ func TestGetComponentReports_InvalidStatusParameter(t *testing.T) {
 
 	t.Run("ValidStatusReturns200", func(t *testing.T) {
 		// Create request with valid status parameter
-		req := httptest.NewRequest("GET", "/components/test-component-status/reports?status=pass", nil)
+		req := httptest.NewRequest("GET", "/catalog/v1/components/test-component-status/reports?status=pass", nil)
 		w := httptest.NewRecorder()
 
 		// Call handler with valid status

--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.1.0
   description: API for managing and discovering components from various sources
 paths:
-  /components:
+  /catalog/v1/components:
     get:
       summary: Get all components
       description: Retrieve a list of all components discovered from configured sources
@@ -24,7 +24,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /components/{componentId}:
+  /catalog/v1/components/{componentId}:
     get:
       summary: Get component by ID
       description: Retrieve a specific component by its unique identifier
@@ -56,7 +56,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /components/{componentId}/reports:
+  /catalog/v1/components/{componentId}/reports:
     get:
       summary: Get reports for component
       description: Retrieve quality check reports for a specific component
@@ -145,18 +145,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /healthz:
-    get:
-      summary: Health check
-      description: Check the health status of the API
-      operationId: getHealth
-      responses:
-        "200":
-          description: Service is healthy
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Health"
+
 components:
   schemas:
     Component:

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -30,8 +30,8 @@ func Start(cfg config.Config) (stop func(), err error) {
 	// Mount healthz
 	mux.Get("/healthz", health.HealthHandler(repo))
 
-	// Mount OpenAPI-generated handlers under /api
-	mux.Mount("/api", api.Handler(api.NewAPIServer(repo)))
+	// Mount catalog API under /api/catalog/v1
+	mux.Mount("/api/catalog/v1", api.Handler(api.NewAPIServer(repo)))
 
 	// Mount reports API under /reports
 	mux.Mount("/reports", reportsapi.Handler(reportsapi.NewAPIServer(repo)))

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -102,7 +102,7 @@ testdata/
 ### **API Validation**
 - Server starts with real sync configuration
 - Tests wait for sync completion (1-10 seconds)
-- API client validates components via GET /api/components
+- API client validates components via GET /api/catalog/v1/components
 - Component names and counts verified
 
 ## Test Scenarios

--- a/backend/tests/component_reports_integration_test.go
+++ b/backend/tests/component_reports_integration_test.go
@@ -63,7 +63,7 @@ func TestComponentReportsAPIEndpoints(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Create API clients
-	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api")
+	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	reportsClient, err := reportsclient.NewClientWithResponses("http://localhost:8080/reports")

--- a/backend/tests/components_test.go
+++ b/backend/tests/components_test.go
@@ -26,7 +26,7 @@ func TestGetComponentsIntegration(t *testing.T) {
 	// Wait briefly for the server to start
 	time.Sleep(100 * time.Millisecond)
 
-	client, err := client.NewClientWithResponses("http://localhost:8080/api")
+	client, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	resp, err := client.GetComponentsWithResponse(context.Background())
@@ -44,7 +44,7 @@ func TestGetComponentByIdIntegration(t *testing.T) {
 	// Wait briefly for the server to start
 	time.Sleep(100 * time.Millisecond)
 
-	client, err := client.NewClientWithResponses("http://localhost:8080/api")
+	client, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	// Test getting a non-existent component
@@ -82,7 +82,7 @@ func TestGetComponentByIdWithSyncIntegration(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Create API client
-	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api")
+	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	// Test getting an existing component

--- a/backend/tests/sync_integration_test.go
+++ b/backend/tests/sync_integration_test.go
@@ -99,7 +99,7 @@ func TestFilesystemSyncIntegration(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Create API client
-	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api")
+	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	// Get components via API
@@ -181,7 +181,7 @@ func TestFilesystemSyncWithSpecificPath(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Create API client
-	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api")
+	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	// Get components via API
@@ -242,7 +242,7 @@ func TestGitSyncIntegration(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	// Create API client
-	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api")
+	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	// Get components via API
@@ -316,7 +316,7 @@ func TestMixedSourcesIntegration(t *testing.T) {
 	time.Sleep(12 * time.Second)
 
 	// Create API client
-	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api")
+	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	// Get components via API
@@ -378,7 +378,7 @@ func TestSyncWithNoSources(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Create API client
-	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api")
+	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	// Get components via API - should be empty since no sync occurred
@@ -417,7 +417,7 @@ func TestSyncErrorHandling(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Create API client
-	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api")
+	apiClient, err := client.NewClientWithResponses("http://localhost:8080/api/catalog/v1")
 	require.NoError(t, err)
 
 	// Get components via API - should be empty due to sync failures

--- a/docs/designs/002-url-scheme.md
+++ b/docs/designs/002-url-scheme.md
@@ -1,0 +1,46 @@
+# Design: API and Web UI URL Scheme
+
+## Context
+**Problem**: Current API structure has potential conflicts between modules and between API routes and future UI routes
+**Solution**: Establish a clear URL scheme that separates API routes by module and prevents conflicts with UI routes
+
+## Goals
+- Establish clear separation between API routes and UI routes
+- Prevent conflicts between different API modules
+- Enable independent versioning per module
+- Provide clean, semantic URL structure
+
+## Constraints
+- Must work with existing Go backend structure
+- Should support future UI development
+- Must maintain backward compatibility where possible
+
+## Design
+
+### API Path Structure (Updated)
+**API Paths (per module with versioning):**
+- `/api/catalog/v1/*` (API module - component catalog)
+- `/api/reports/v1/*` (Reports module)
+- `/api/sync/v1/*` (Sync module)
+
+**UI Paths:**
+- `/` (components list)
+- `/component/{id}` (component details)
+- `/settings`
+- `/reports` (reports UI page)
+- `/sync` (sync UI page)
+
+### Rationale for API Structure
+- **Module ownership**: Each module owns its namespace completely (catalog, reports, sync)
+- **Independent versioning**: Each module can evolve independently (catalog v2 while reports stays v1)
+- **No conflicts**: UI routes are clean and semantic, no interference with API paths
+- **Clear separation**: Management API (catalog) vs. service APIs (reports, sync)
+
+## Tradeoffs
+
+### API Structure
+- **Chosen**: Versioned, namespaced APIs per module
+- **Benefit**: No conflicts, independent evolution
+- **Cost**: Slightly more verbose paths
+
+This URL scheme provides clean separation between UI and API routes while enabling independent module evolution.


### PR DESCRIPTION
## Summary

This PR implements the catalog API module with the new URL scheme `/api/catalog/v1/*` as specified in the URL scheme design.

## Changes

- **Server Routing**: Updated `backend/internal/server/server.go` to mount catalog API under `/api/catalog/v1`
- **OpenAPI Spec**: Updated `backend/api/openapi.yaml` to use `/catalog/v1/*` paths and removed health check endpoint
- **API Code**: Regenerated API code with `make backend/gen-api-server backend/gen-api-client`
- **Tests**: Updated all catalog API tests in `backend/api/handlers_test.go` and `backend/tests/` to use new paths
- **Documentation**: Updated test README to reflect new catalog API paths

## Acceptance Criteria

- [x] Catalog API accessible at `/api/catalog/v1/*` paths
- [x] All existing functionality preserved
- [x] All tests updated and passing
- [x] Documentation updated
- [x] No health check endpoint in OpenAPI spec

## Testing

- All unit tests pass
- All integration tests pass
- Linter passes with no issues
- API functionality verified through integration tests

This establishes the catalog API as the first module under the new versioned, namespaced structure as defined in the URL scheme design.

Closes #19