### PR TITLE
fix: update sync API path to follow URL scheme design

### DIFF
--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -44,8 +44,8 @@ func Start(cfg config.Config) (stop func(), err error) {
 	// Start sync service (will log warning and return if no sources configured)
 	go syncService.StartPeriodicSync(syncCtx)
 
-	// Mount sync API under /sync
-	mux.Mount("/sync", syncapi.Handler(syncapi.NewSyncAPIServer(syncService)))
+	// Mount sync API under /api/sync/v1
+	mux.Mount("/api/sync/v1", syncapi.Handler(syncapi.NewSyncAPIServer(syncService)))
 
 	srv := &http.Server{
 		Addr:              ":8080",

--- a/backend/tests/sync_api_integration_test.go
+++ b/backend/tests/sync_api_integration_test.go
@@ -38,7 +38,7 @@ func TestSyncAPIEndpoints(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Create sync API client
-	syncClient, err := client.NewClientWithResponses("http://localhost:8080/sync")
+	syncClient, err := client.NewClientWithResponses("http://localhost:8080/api/sync/v1")
 	require.NoError(t, err)
 
 	t.Run("GetSyncSources", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestSyncAPIWithNoSources(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Create sync API client
-	syncClient, err := client.NewClientWithResponses("http://localhost:8080/sync")
+	syncClient, err := client.NewClientWithResponses("http://localhost:8080/api/sync/v1")
 	require.NoError(t, err)
 
 	t.Run("GetSyncSourcesEmpty", func(t *testing.T) {

--- a/backend/tests/utils.go
+++ b/backend/tests/utils.go
@@ -16,7 +16,7 @@ func waitForSyncCompletion(t *testing.T, timeout time.Duration) {
 	defer cancel()
 
 	// Create sync client
-	syncClient, err := syncclient.NewClientWithResponses("http://localhost:8080/sync")
+	syncClient, err := syncclient.NewClientWithResponses("http://localhost:8080/api/sync/v1")
 	require.NoError(t, err)
 
 	// Poll for sync completion


### PR DESCRIPTION
## Summary

This PR fixes issue #21 by updating the sync module API path to follow the URL scheme design document.

## Changes

- **Server Configuration**: Updated sync API mount from `/sync` to `/api/sync/v1`
- **Test Files**: Updated all test files to use the new API path
- **URL Scheme Compliance**: Now follows the design document's URL scheme:
  - `/api/catalog/v1/*` (API module)
  - `/api/reports/v1/*` (Reports module) 
  - `/api/sync/v1/*` (Sync module)

## Testing

✅ All tests pass including sync API integration tests
✅ Linter passes with no issues
✅ URL scheme now properly aligned with design document

## API Endpoints

The sync API endpoints are now accessible at:
- `GET /api/sync/v1/sources` - Get all sync sources
- `GET /api/sync/v1/sources/{id}` - Get specific sync source
- `GET /api/sync/v1/sources/{id}/status` - Get sync status
- `POST /api/sync/v1/sources/{id}/trigger` - Trigger manual sync

Closes #21