### PR TITLE
Lit migration: migrate component-details to Lit (Closes #62)

### DIFF
--- a/frontend/src/components/component-details.ts
+++ b/frontend/src/components/component-details.ts
@@ -1,4 +1,4 @@
-import { BaseComponent } from "../utils/base-component";
+import { LitElement, html } from "lit";
 import {
   componentDetails,
   loading,
@@ -7,132 +7,78 @@ import {
   reportsLoading,
   reportsError,
   type CheckReport,
+  type Component,
 } from "../stores/app-store";
-import { escapeHtml } from "../utils";
 import "../ui/ui-badge";
 
-export class ComponentDetails extends BaseComponent {
-  connectedCallback() {
-    this.bindState(componentDetails, (component) => this.render(component));
-    this.bindState(loading, (loading) => this.showLoading(loading));
-    this.bindState(error, (error) => this.showError(error));
-    this.bindState(latestReports, (reports) => this.renderReports(reports));
-    this.bindState(reportsLoading, (loading) =>
-      this.showReportsLoading(loading),
+export class ComponentDetails extends LitElement {
+  // Keep unsubscribe handles for cleanup and test visibility
+  private subscriptions: Array<() => void> = [];
+
+  private currentComponent: Component | null = null;
+  private isLoading = false;
+  private errorMessage: string | null = null;
+  private currentReports: readonly CheckReport[] = [];
+  private isReportsLoading = false;
+  private reportsErrorMessage: string | null = null;
+
+  // Render into light DOM to preserve global styles and test selectors
+  protected createRenderRoot(): this {
+    return this;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    // Subscribe to stores and trigger updates
+    this.subscriptions.push(
+      componentDetails.subscribe((value) => {
+        this.currentComponent = value;
+        this.requestUpdate();
+      }),
     );
-    this.bindState(reportsError, (error) => this.showReportsError(error));
-  }
-
-  private render(component: any) {
-    if (!component) {
-      this.innerHTML = "";
-      return;
-    }
-
-    // Pre-compute safe display texts for cleaner templates
-    const vm = this.buildViewModel(component);
-
-    this.innerHTML = `
-      <div class="bg-white shadow overflow-hidden sm:rounded-lg" data-testid="component-details">
-        <div class="px-4 py-5 sm:px-6">
-          <h3 class="text-lg leading-6 font-medium text-gray-900" data-testid="component-name">${vm.nameText}</h3>
-          <p class="mt-1 max-w-2xl text-sm text-gray-500" data-testid="component-id">ID: ${vm.idText}</p>
-        </div>
-        <div class="border-t border-gray-200">
-          <dl>
-            <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-              <dt class="text-sm font-medium text-gray-500" data-testid="description-label">Description</dt>
-              <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2" data-testid="component-description">${vm.descriptionText}</dd>
-            </div>
-            <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-              <dt class="text-sm font-medium text-gray-500" data-testid="team-label">Team</dt>
-              <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2" data-testid="component-team">${vm.teamText}</dd>
-            </div>
-            <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-              <dt class="text-sm font-medium text-gray-500" data-testid="maintainers-label">Maintainers</dt>
-              <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2" data-testid="component-maintainers">${vm.maintainersText}</dd>
-            </div>
-            <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-              <dt class="text-sm font-medium text-gray-500" data-testid="reports-label">Latest Quality Checks</dt>
-              <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2" data-testid="component-reports">
-                <div id="reports-container"></div>
-              </dd>
-            </div>
-          </dl>
-        </div>
-        <div class="px-4 py-3 bg-gray-50 text-right sm:px-6">
-          <a href="/" class="text-sm font-medium text-indigo-600 hover:text-indigo-500" data-testid="back-to-components">
-            ← Back to Components
-          </a>
-        </div>
-      </div>
-    `;
-
-    // Initialize reports section with current state
-    this.renderReports(latestReports.get());
-  }
-
-  private buildViewModel(component: any) {
-    const nameText = escapeHtml(component?.name ?? "");
-    const idText = escapeHtml(component?.id ?? component?.name ?? "");
-    const descriptionText = escapeHtml(
-      component?.description || "No description available",
+    this.subscriptions.push(
+      loading.subscribe((value) => {
+        this.isLoading = value;
+        this.requestUpdate();
+      }),
     );
-    const teamText = escapeHtml(component?.owners?.team || "No team assigned");
-    const maintainersText = escapeHtml(
-      (component?.owners?.maintainers || []).join(", ") ||
-        "No maintainers assigned",
+    this.subscriptions.push(
+      error.subscribe((value) => {
+        this.errorMessage = value;
+        this.requestUpdate();
+      }),
     );
-    return { nameText, idText, descriptionText, teamText, maintainersText };
+    this.subscriptions.push(
+      latestReports.subscribe((value) => {
+        this.currentReports = value as readonly CheckReport[];
+        this.requestUpdate();
+      }),
+    );
+    this.subscriptions.push(
+      reportsLoading.subscribe((value) => {
+        this.isReportsLoading = value;
+        this.requestUpdate();
+      }),
+    );
+    this.subscriptions.push(
+      reportsError.subscribe((value) => {
+        this.reportsErrorMessage = value;
+        this.requestUpdate();
+      }),
+    );
   }
 
-  private renderReports(reports: readonly CheckReport[]) {
-    const container = this.querySelector("#reports-container");
-    if (!container) return;
-
-    if (reports.length === 0) {
-      container.innerHTML = `
-        <div class="text-gray-500 italic" data-testid="no-reports">
-          No quality checks available
-        </div>
-      `;
-      return;
-    }
-
-    const reportsList = reports
-      .map((report) => {
-        return `
-        <div class="flex items-center justify-between py-2 border-b border-gray-100 last:border-b-0" data-testid="report-item">
-          <span class="text-sm font-medium text-gray-900" data-testid="check-name">
-            ${escapeHtml(report.check_slug)}
-          </span>
-          <div class="flex items-center space-x-2">
-            <ui-badge status="${escapeHtml(
-              report.status,
-            )}" data-testid="check-status"></ui-badge>
-            <span class="text-xs text-gray-500" data-testid="check-timestamp">
-              ${this.formatTimestamp(report.timestamp)}
-            </span>
-          </div>
-        </div>
-      `;
-      })
-      .join("");
-
-    container.innerHTML = `
-      <div class="space-y-1" data-testid="reports-list">
-        ${reportsList}
-      </div>
-    `;
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.subscriptions.forEach((off) => off());
+    this.subscriptions = [];
   }
-
-  // Status presentation is handled by <ui-badge>
 
   private formatTimestamp(timestamp: string): string {
     try {
       const date = new Date(timestamp);
       if (isNaN(date.getTime())) {
-        return escapeHtml(String(timestamp));
+        return String(timestamp);
       }
       return (
         date.toLocaleDateString() +
@@ -140,15 +86,238 @@ export class ComponentDetails extends BaseComponent {
         date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
       );
     } catch {
-      return escapeHtml(String(timestamp));
+      return String(timestamp);
     }
   }
 
-  private showLoading(isLoading: boolean) {
-    if (isLoading) {
-      this.innerHTML = `
+  render() {
+    // Error state has highest priority
+    if (this.errorMessage) {
+      return html`
         <div data-testid="component-details">
-          <div class="bg-white shadow overflow-hidden sm:rounded-lg" data-testid="component-details-loading">
+          <div
+            class="bg-white shadow overflow-hidden sm:rounded-lg"
+            data-testid="component-details-error"
+          >
+            <div class="px-4 py-5 sm:px-6">
+              <div class="rounded-md bg-red-50 p-4">
+                <div class="flex">
+                  <div class="flex-shrink-0">
+                    <svg
+                      class="h-5 w-5 text-red-400"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                        clip-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div class="ml-3">
+                    <h3
+                      class="text-sm font-medium text-red-800"
+                      data-testid="error-title"
+                    >
+                      Error loading component
+                    </h3>
+                    <div
+                      class="mt-2 text-sm text-red-700"
+                      data-testid="error-message"
+                    >
+                      ${this.errorMessage}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="px-4 py-3 bg-gray-50 text-right sm:px-6">
+              <a
+                href="/"
+                class="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+                data-testid="back-to-components"
+                >← Back to Components</a
+              >
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    // Empty when no component
+    if (this.currentComponent) {
+      const component = this.currentComponent;
+      const idText = component.id || component.name || "";
+      const descriptionText =
+        component.description || "No description available";
+      const teamText = component.owners?.team || "No team assigned";
+      const maintainersText =
+        (component.owners?.maintainers || []).join(", ") ||
+        "No maintainers assigned";
+
+      return html`
+        <div
+          class="bg-white shadow overflow-hidden sm:rounded-lg"
+          data-testid="component-details"
+        >
+          <div class="px-4 py-5 sm:px-6">
+            <h3
+              class="text-lg leading-6 font-medium text-gray-900"
+              data-testid="component-name"
+            >
+              ${component.name || ""}
+            </h3>
+            <p
+              class="mt-1 max-w-2xl text-sm text-gray-500"
+              data-testid="component-id"
+            >
+              ID: ${idText}
+            </p>
+          </div>
+          <div class="border-t border-gray-200">
+            <dl>
+              <div
+                class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6"
+              >
+                <dt
+                  class="text-sm font-medium text-gray-500"
+                  data-testid="description-label"
+                >
+                  Description
+                </dt>
+                <dd
+                  class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"
+                  data-testid="component-description"
+                >
+                  ${descriptionText}
+                </dd>
+              </div>
+              <div
+                class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6"
+              >
+                <dt
+                  class="text-sm font-medium text-gray-500"
+                  data-testid="team-label"
+                >
+                  Team
+                </dt>
+                <dd
+                  class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"
+                  data-testid="component-team"
+                >
+                  ${teamText}
+                </dd>
+              </div>
+              <div
+                class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6"
+              >
+                <dt
+                  class="text-sm font-medium text-gray-500"
+                  data-testid="maintainers-label"
+                >
+                  Maintainers
+                </dt>
+                <dd
+                  class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"
+                  data-testid="component-maintainers"
+                >
+                  ${maintainersText}
+                </dd>
+              </div>
+              <div
+                class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6"
+              >
+                <dt
+                  class="text-sm font-medium text-gray-500"
+                  data-testid="reports-label"
+                >
+                  Latest Quality Checks
+                </dt>
+                <dd
+                  class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"
+                  data-testid="component-reports"
+                >
+                  <div id="reports-container">
+                    ${this.isReportsLoading
+                      ? html`<div
+                          class="text-gray-500 text-sm"
+                          data-testid="reports-loading"
+                        >
+                          Loading quality checks...
+                        </div>`
+                      : this.reportsErrorMessage
+                        ? html`<div
+                            class="text-red-600 text-sm"
+                            data-testid="reports-error"
+                          >
+                            Error loading quality checks:
+                            ${this.reportsErrorMessage}
+                          </div>`
+                        : (this.currentReports?.length || 0) === 0
+                          ? html`<div
+                              class="text-gray-500 italic"
+                              data-testid="no-reports"
+                            >
+                              No quality checks available
+                            </div>`
+                          : html`<div
+                              class="space-y-1"
+                              data-testid="reports-list"
+                            >
+                              ${this.currentReports.map(
+                                (report) => html`
+                                  <div
+                                    class="flex items-center justify-between py-2 border-b border-gray-100 last:border-b-0"
+                                    data-testid="report-item"
+                                  >
+                                    <span
+                                      class="text-sm font-medium text-gray-900"
+                                      data-testid="check-name"
+                                      >${report.check_slug}</span
+                                    >
+                                    <div class="flex items-center space-x-2">
+                                      <ui-badge
+                                        status="${report.status}"
+                                        data-testid="check-status"
+                                      ></ui-badge>
+                                      <span
+                                        class="text-xs text-gray-500"
+                                        data-testid="check-timestamp"
+                                        >${this.formatTimestamp(
+                                          report.timestamp,
+                                        )}</span
+                                      >
+                                    </div>
+                                  </div>
+                                `,
+                              )}
+                            </div>`}
+                  </div>
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div class="px-4 py-3 bg-gray-50 text-right sm:px-6">
+            <a
+              href="/"
+              class="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+              data-testid="back-to-components"
+              >← Back to Components</a
+            >
+          </div>
+        </div>
+      `;
+    }
+
+    // Loading fallback when no component yet
+    if (this.isLoading) {
+      return html`
+        <div data-testid="component-details">
+          <div
+            class="bg-white shadow overflow-hidden sm:rounded-lg"
+            data-testid="component-details-loading"
+          >
             <div class="px-4 py-5 sm:px-6">
               <div class="animate-pulse">
                 <div class="h-4 bg-gray-200 rounded w-1/3 mb-2"></div>
@@ -156,19 +325,25 @@ export class ComponentDetails extends BaseComponent {
               </div>
             </div>
             <div class="border-t border-gray-200">
-              <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <div
+                class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6"
+              >
                 <div class="h-3 bg-gray-200 rounded w-1/4"></div>
                 <div class="mt-1 sm:mt-0 sm:col-span-2">
                   <div class="h-3 bg-gray-200 rounded w-full"></div>
                 </div>
               </div>
-              <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <div
+                class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6"
+              >
                 <div class="h-3 bg-gray-200 rounded w-1/4"></div>
                 <div class="mt-1 sm:mt-0 sm:col-span-2">
                   <div class="h-3 bg-gray-200 rounded w-1/2"></div>
                 </div>
               </div>
-              <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <div
+                class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6"
+              >
                 <div class="h-3 bg-gray-200 rounded w-1/4"></div>
                 <div class="mt-1 sm:mt-0 sm:col-span-2">
                   <div class="h-3 bg-gray-200 rounded w-2/3"></div>
@@ -179,64 +354,12 @@ export class ComponentDetails extends BaseComponent {
         </div>
       `;
     }
-  }
 
-  private showError(errorMessage: string | null) {
-    if (errorMessage) {
-      this.innerHTML = `
-        <div data-testid="component-details">
-          <div class="bg-white shadow overflow-hidden sm:rounded-lg" data-testid="component-details-error">
-            <div class="px-4 py-5 sm:px-6">
-              <div class="rounded-md bg-red-50 p-4">
-                <div class="flex">
-                  <div class="flex-shrink-0">
-                    <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-                    </svg>
-                  </div>
-                  <div class="ml-3">
-                    <h3 class="text-sm font-medium text-red-800" data-testid="error-title">Error loading component</h3>
-                    <div class="mt-2 text-sm text-red-700" data-testid="error-message">${escapeHtml(
-                      errorMessage,
-                    )}</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="px-4 py-3 bg-gray-50 text-right sm:px-6">
-              <a href="/" class="text-sm font-medium text-indigo-600 hover:text-indigo-500" data-testid="back-to-components">← Back to Components</a>
-            </div>
-          </div>
-        </div>
-      `;
-    }
-  }
-
-  private showReportsLoading(loading: boolean) {
-    const container = this.querySelector("#reports-container");
-    if (!container) return;
-
-    if (loading) {
-      container.innerHTML = `
-        <div class="text-gray-500 text-sm" data-testid="reports-loading">
-          Loading quality checks...
-        </div>
-      `;
-    }
-  }
-
-  private showReportsError(error: string | null) {
-    const container = this.querySelector("#reports-container");
-    if (!container) return;
-
-    if (error) {
-      container.innerHTML = `
-        <div class="text-red-600 text-sm" data-testid="reports-error">
-          Error loading quality checks: ${escapeHtml(error)}
-        </div>
-      `;
-    }
+    // Default empty
+    return html``;
   }
 }
 
-customElements.define("component-details", ComponentDetails);
+if (!customElements.get("component-details")) {
+  customElements.define("component-details", ComponentDetails);
+}

--- a/frontend/src/components/component-details.ts
+++ b/frontend/src/components/component-details.ts
@@ -29,6 +29,14 @@ export class ComponentDetails extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
+    // Seed initial state from current store values before subscribing
+    this.currentComponent = componentDetails.get();
+    this.isLoading = loading.get();
+    this.errorMessage = error.get();
+    this.currentReports = latestReports.get();
+    this.isReportsLoading = reportsLoading.get();
+    this.reportsErrorMessage = reportsError.get();
+    this.requestUpdate();
     // Subscribe to stores and trigger updates
     this.subscriptions.push(
       componentDetails.subscribe((value) => {
@@ -247,13 +255,7 @@ export class ComponentDetails extends LitElement {
                           Loading quality checks...
                         </div>`
                       : this.reportsErrorMessage
-                        ? html`<div
-                            class="text-red-600 text-sm"
-                            data-testid="reports-error"
-                          >
-                            Error loading quality checks:
-                            ${this.reportsErrorMessage}
-                          </div>`
+                        ? html`<div class="text-red-600 text-sm" data-testid="reports-error">Error loading quality checks: ${this.reportsErrorMessage}</div>`
                         : (this.currentReports?.length || 0) === 0
                           ? html`<div
                               class="text-gray-500 italic"


### PR DESCRIPTION
## Summary
- Migrate `component-details` from `HTMLElement` to `LitElement`
- Bind to nanostores: `$componentDetails`, `$latestReports`, loading, errors
- Keep light DOM, Tailwind classes, and data-testids
- Preserve UI semantics and status badges using `ui-badge`

## Why
Aligns the details view with the new Lit architecture and consistent component model.

## Changes
- `frontend/src/components/component-details.ts`: rewrite as Lit with subscriptions
- `frontend/src/components/component-details.test.ts`: adapt tests to Lit's async rendering

## Testing
- Unit: `cd frontend && bun run test:unit` — all passing locally
- Type-check: `cd frontend && bun run type-check` — pass
- Format: `cd frontend && bun run format:check` — clean
- E2E: uses Playwright with Docker webServer; locally requires Docker running (`bun run test:e2e`)

## Notes
- Renders in light DOM to maintain existing selectors and global styles.
- No API or store changes; UI behavior preserved.