### PR TITLE
feat: add CSS tokens and theme groundwork

### DIFF
--- a/docs/designs/006-css-tokens-and-theme.md
+++ b/docs/designs/006-css-tokens-and-theme.md
@@ -1,0 +1,21 @@
+## ADR: CSS Tokens and Theme Groundwork
+
+### Context
+We are migrating from Tailwind-first styling to Lit components that consume semantic CSS custom properties. This enables theming (light/dark) that cascades through shadow DOM via custom properties.
+
+### Decision
+- Introduce core and semantic CSS tokens loaded once globally via `src/styles.css`.
+- Provide `data-theme` attribute on `:root` to switch themes.
+- Keep Tailwind for layout and utility usage during the transition.
+- First adopter: `ui-badge` component uses semantic tokens with fallbacks.
+
+### Implementation
+- Tokens: `frontend/src/ui/tokens/{core.css, palette.css, semantic.css, themes/{light.css,dark.css}}`
+- Bootstrap: import tokens via `src/styles.css` and set theme via `src/ui/theme/theme-provider.ts`.
+- Component migration pattern: replace hard-coded colors with semantic variables.
+
+### Consequences
+- Components remain functional without tokens thanks to fallbacks.
+- Subsequent components can migrate incrementally.
+
+

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,3 +33,6 @@ This milestone adds quality monitoring capabilities to the software catalog.
 - **Simple Design**: Minimal, functional UI focused on usability over aesthetics.
 
 This milestone provides a basic web interface for interacting with the component registry and quality check data.
+
+### Design Notes
+- See `docs/designs/006-css-tokens-and-theme.md` for the CSS tokens and theme groundwork used by UI components (initially `ui-badge`).

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,23 +1,10 @@
 import { serve } from "bun";
 
-const API_HOST = process.env.VITE_API_HOST || "http://localhost:8080";
-
 const server = serve({
   port: 3000,
   async fetch(req) {
     const url = new URL(req.url);
     let filePath = url.pathname;
-
-    // Proxy API calls to backend
-    if (filePath.startsWith("/api/")) {
-      const apiUrl = `${API_HOST}${filePath}`;
-      const apiResponse = await fetch(apiUrl, {
-        method: req.method,
-        headers: req.headers,
-        body: req.body,
-      });
-      return apiResponse;
-    }
 
     // Handle client-side routing - serve index.html for app routes
     // Serve index.html for any non-dist path (SPA)

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,10 +1,23 @@
 import { serve } from "bun";
 
+const API_HOST = process.env.VITE_API_HOST || "http://localhost:8080";
+
 const server = serve({
   port: 3000,
   async fetch(req) {
     const url = new URL(req.url);
     let filePath = url.pathname;
+
+    // Proxy API calls to backend
+    if (filePath.startsWith("/api/")) {
+      const apiUrl = `${API_HOST}${filePath}`;
+      const apiResponse = await fetch(apiUrl, {
+        method: req.method,
+        headers: req.headers,
+        body: req.body,
+      });
+      return apiResponse;
+    }
 
     // Handle client-side routing - serve index.html for app routes
     // Serve index.html for any non-dist path (SPA)

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,7 @@
 // Initialize API configuration first
 import "./config/api";
+// Initialize theme provider (sets data-theme if absent)
+import "./ui/theme/theme-provider";
 
 // Register all components explicitly
 import "./components/component-details";

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Design tokens and themes */
+@import "./ui/tokens/core.css";
+@import "./ui/tokens/palette.css";
+@import "./ui/tokens/semantic.css";
+@import "./ui/tokens/themes/light.css";
+@import "./ui/tokens/themes/dark.css";

--- a/frontend/src/ui/theme/theme-provider.ts
+++ b/frontend/src/ui/theme/theme-provider.ts
@@ -1,0 +1,10 @@
+export type Theme = "light" | "dark";
+
+export function setTheme(theme: Theme): void {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+// Initialize default theme once
+if (!document.documentElement.getAttribute("data-theme")) {
+  setTheme("light");
+}

--- a/frontend/src/ui/tokens/core.css
+++ b/frontend/src/ui/tokens/core.css
@@ -1,0 +1,45 @@
+/* Core design tokens: spacing, radii, typography, elevations, z-index */
+
+:root {
+  /* Space scale */
+  --space-0: 0rem;
+  --space-0-5: 0.125rem;
+  --space-1: 0.25rem;
+  --space-1-5: 0.375rem;
+  --space-2: 0.5rem;
+  --space-2-5: 0.625rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+
+  /* Radius scale */
+  --radius-0: 0;
+  --radius-1: 0.125rem;
+  --radius-2: 0.25rem;
+  --radius-3: 0.375rem;
+  --radius-4: 0.5rem;
+  --radius-full: 9999px;
+  --radius-pill: var(--radius-full);
+
+  /* Typography scale */
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Shadows */
+  --shadow-0: none;
+  --shadow-1: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-2: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+
+  /* Z-index scale */
+  --z-0: 0;
+  --z-10: 10;
+  --z-20: 20;
+  --z-30: 30;
+  --z-40: 40;
+  --z-50: 50;
+}

--- a/frontend/src/ui/tokens/palette.css
+++ b/frontend/src/ui/tokens/palette.css
@@ -1,0 +1,38 @@
+/* Color palette tokens (Tailwind-aligned values) */
+
+:root {
+  --palette-white: rgb(255 255 255);
+  --palette-black: rgb(0 0 0);
+
+  /* Gray */
+  --palette-gray-50: rgb(249 250 251);
+  --palette-gray-100: rgb(243 244 246);
+  --palette-gray-200: rgb(229 231 235);
+  --palette-gray-700: rgb(55 65 81);
+  --palette-gray-800: rgb(31 41 55);
+  --palette-gray-900: rgb(17 24 39);
+
+  /* Green */
+  --palette-green-100: rgb(220 252 231);
+  --palette-green-300: rgb(134 239 172);
+  --palette-green-600: rgb(22 163 74);
+  --palette-green-900: rgb(20 83 45);
+
+  /* Red */
+  --palette-red-100: rgb(254 226 226);
+  --palette-red-300: rgb(252 165 165);
+  --palette-red-600: rgb(220 38 38);
+  --palette-red-900: rgb(127 29 29);
+
+  /* Yellow / Amber */
+  --palette-yellow-100: rgb(254 249 195);
+  --palette-yellow-200: rgb(254 240 138);
+  --palette-yellow-700: rgb(161 98 7);
+  --palette-amber-900: rgb(113 63 18);
+
+  /* Blue */
+  --palette-blue-100: rgb(219 234 254);
+  --palette-blue-300: rgb(147 197 253);
+  --palette-blue-700: rgb(29 78 216);
+  --palette-blue-900: rgb(30 58 138);
+}

--- a/frontend/src/ui/tokens/semantic.css
+++ b/frontend/src/ui/tokens/semantic.css
@@ -1,0 +1,24 @@
+/* Semantic tokens map roles to palette. Defaults align with light theme. */
+
+:root {
+  /* Content/base roles */
+  --color-bg: var(--palette-white);
+  --color-fg: var(--palette-gray-900);
+  --color-border: var(--palette-gray-200);
+
+  /* Status roles used by ui-badge */
+  --color-success-bg: var(--palette-green-100);
+  --color-success-fg: var(--palette-green-600);
+
+  --color-danger-bg: var(--palette-red-100);
+  --color-danger-fg: var(--palette-red-600);
+
+  --color-warning-bg: var(--palette-yellow-100);
+  --color-warning-fg: var(--palette-yellow-700);
+
+  --color-info-bg: var(--palette-blue-100);
+  --color-info-fg: var(--palette-blue-700);
+
+  --color-neutral-bg: var(--palette-gray-100);
+  --color-neutral-fg: var(--palette-gray-700);
+}

--- a/frontend/src/ui/tokens/themes/dark.css
+++ b/frontend/src/ui/tokens/themes/dark.css
@@ -1,0 +1,22 @@
+/* Dark theme overrides */
+
+:root[data-theme="dark"] {
+  --color-bg: var(--palette-gray-900);
+  --color-fg: var(--palette-gray-200);
+  --color-border: var(--palette-gray-700);
+
+  --color-success-bg: var(--palette-green-900);
+  --color-success-fg: var(--palette-green-300);
+
+  --color-danger-bg: var(--palette-red-900);
+  --color-danger-fg: var(--palette-red-300);
+
+  --color-warning-bg: var(--palette-amber-900);
+  --color-warning-fg: var(--palette-yellow-200);
+
+  --color-info-bg: var(--palette-blue-900);
+  --color-info-fg: var(--palette-blue-300);
+
+  --color-neutral-bg: var(--palette-gray-800);
+  --color-neutral-fg: var(--palette-gray-200);
+}

--- a/frontend/src/ui/tokens/themes/light.css
+++ b/frontend/src/ui/tokens/themes/light.css
@@ -1,0 +1,22 @@
+/* Light theme overrides (explicit for clarity) */
+
+:root[data-theme="light"] {
+  --color-bg: var(--palette-white);
+  --color-fg: var(--palette-gray-900);
+  --color-border: var(--palette-gray-200);
+
+  --color-success-bg: var(--palette-green-100);
+  --color-success-fg: var(--palette-green-600);
+
+  --color-danger-bg: var(--palette-red-100);
+  --color-danger-fg: var(--palette-red-600);
+
+  --color-warning-bg: var(--palette-yellow-100);
+  --color-warning-fg: var(--palette-yellow-700);
+
+  --color-info-bg: var(--palette-blue-100);
+  --color-info-fg: var(--palette-blue-700);
+
+  --color-neutral-bg: var(--palette-gray-100);
+  --color-neutral-fg: var(--palette-gray-700);
+}

--- a/frontend/src/ui/ui-badge.ts
+++ b/frontend/src/ui/ui-badge.ts
@@ -12,24 +12,6 @@ type StatusVariant =
   | "completed"
   | "default";
 
-function getColorClasses(status: StatusVariant): string {
-  switch (status) {
-    case "pass":
-      return "bg-green-100 text-green-800";
-    case "fail":
-    case "error":
-    case "unknown":
-      return "bg-red-100 text-red-800";
-    case "disabled":
-    case "skipped":
-      return "bg-yellow-100 text-yellow-800";
-    case "completed":
-      return "bg-blue-100 text-blue-800";
-    default:
-      return "bg-gray-100 text-gray-800";
-  }
-}
-
 function getIconSvg(status: StatusVariant): string {
   switch (status) {
     case "pass":
@@ -73,45 +55,47 @@ export class UiBadge extends LitElement {
     :host {
       display: inline-flex;
       align-items: center;
-      padding: 0.25rem 0.5rem;
-      border-radius: 9999px;
-      font-size: 0.75rem;
-      font-weight: 500;
+      padding: var(--space-1, 0.25rem) var(--space-2, 0.5rem);
+      border-radius: var(--radius-pill, 9999px);
+      font-size: var(--font-size-xs, 0.75rem);
+      font-weight: var(--font-weight-medium, 500);
+      background-color: var(--color-neutral-bg, rgb(243 244 246));
+      color: var(--color-neutral-fg, rgb(55 65 81));
     }
 
     .icon {
       width: 0.75rem;
       height: 0.75rem;
-      margin-right: 0.25rem;
+      margin-right: var(--space-1, 0.25rem);
     }
 
     /* Status-based styling */
     :host(.pass) {
-      background-color: rgb(220 252 231);
-      color: rgb(22 163 74);
+      background-color: var(--color-success-bg, rgb(220 252 231));
+      color: var(--color-success-fg, rgb(22 163 74));
     }
 
     :host(.fail),
     :host(.error),
     :host(.unknown) {
-      background-color: rgb(254 226 226);
-      color: rgb(220 38 38);
+      background-color: var(--color-danger-bg, rgb(254 226 226));
+      color: var(--color-danger-fg, rgb(220 38 38));
     }
 
     :host(.disabled),
     :host(.skipped) {
-      background-color: rgb(254 249 195);
-      color: rgb(161 98 7);
+      background-color: var(--color-warning-bg, rgb(254 249 195));
+      color: var(--color-warning-fg, rgb(161 98 7));
     }
 
     :host(.completed) {
-      background-color: rgb(219 234 254);
-      color: rgb(29 78 216);
+      background-color: var(--color-info-bg, rgb(219 234 254));
+      color: var(--color-info-fg, rgb(29 78 216));
     }
 
     :host(.default) {
-      background-color: rgb(243 244 246);
-      color: rgb(55 65 81);
+      background-color: var(--color-neutral-bg, rgb(243 244 246));
+      color: var(--color-neutral-fg, rgb(55 65 81));
     }
   `;
 


### PR DESCRIPTION
## Description

Implements CSS tokens and theme groundwork as described in Issue #80. This establishes the foundation for migrating from Tailwind-first styling to Lit components that consume semantic CSS custom properties, enabling theming that cascades through shadow DOM.

## Changes

- **Token System**: Added palette, semantic, and theme CSS files under `frontend/src/ui/tokens/`
  - `palette.css`: Central color definitions (Tailwind-aligned)
  - `semantic.css`: Role-based mappings (e.g., `--color-success-bg`)
  - `themes/light.css` & `themes/dark.css`: Theme-specific overrides
  - `core.css`: Spacing, typography, shadows, z-index scales

- **Theme Provider**: Minimal theme provider with `data-theme` attribute support
  - `frontend/src/ui/theme/theme-provider.ts`: Sets root `data-theme` attribute
  - Imported in `frontend/src/main.ts` for initialization

- **Component Migration**: Updated `ui-badge` to use semantic CSS variables
  - Removed hard-coded colors in favor of semantic tokens
  - Maintains fallbacks for backward compatibility
  - Status variants map to semantic roles (success, danger, warning, info, neutral)

- **Global Integration**: Tokens imported in `frontend/src/styles.css` for cascading
  - Import order: core → palette → semantic → themes
  - Ensures tokens are available to all components

- **Documentation**: Added ADR and roadmap reference
  - `docs/designs/006-css-tokens-and-theme.md`: Decision record
  - Updated `docs/roadmap.md` with reference to the ADR

## Testing

- ✅ Unit tests pass
- ✅ Code formatting applied
- ✅ Linter checks pass
- ⚠️ Component/UI tests have existing issues (unrelated to this change)

## Usage

The theme can be toggled at runtime:
```ts
import { setTheme } from "./ui/theme/theme-provider";
setTheme("dark"); // or "light"
```

Components automatically react to theme changes via CSS variables without re-renders.

## Acceptance Criteria

- [x] Tokens load once, apply across pages and components
- [x] Light/dark switch flips semantic colors only (no component code changes)
- [x] Docs added and referenced from `docs/roadmap.md`
- [x] `ui-badge` uses semantic tokens with fallbacks

Fixes #80